### PR TITLE
Use injected ScenarioContext in Specflow feature steps

### DIFF
--- a/Sources/TalentAgileShop.Cart.Tests/Steps/CartSteps.cs
+++ b/Sources/TalentAgileShop.Cart.Tests/Steps/CartSteps.cs
@@ -9,18 +9,25 @@ namespace TalentAgileShop.Cart.Tests.Steps
     [Binding]
     public class CartSteps
     {
+        private readonly ScenarioContext _scenarioContext;
+
+        public CartSteps(ScenarioContext scenarioContext)
+        {
+            _scenarioContext = scenarioContext;
+        }
+
         [Given("a cart")]
         public void GivenACart()
         {
-            ScenarioContext.Current["Cart"] = new List<CartItem>();
-            ScenarioContext.Current["Code"] = null;
+            _scenarioContext["Cart"] = new List<CartItem>();
+            _scenarioContext["Code"] = null;
         }
 
 
         [Given(@"(.*) (.*) product with a price of (.*)")]
         public void GivenSmallProductWithAPriceOf(int count, ProductSize size,  decimal price)
         {
-            var products = ScenarioContext.Current["Cart"] as List<CartItem>;
+            var products = _scenarioContext["Cart"] as List<CartItem>;
 
             products.AddProduct(price,count,size);
         }
@@ -28,27 +35,27 @@ namespace TalentAgileShop.Cart.Tests.Steps
         [Given(@"the discountCode (.*)")]
         public void GivenSmallProductWithAPriceOf(string discountCode)
         {
-            ScenarioContext.Current["Code"] = discountCode;
+            _scenarioContext["Code"] = discountCode;
         }
 
         [When(@"I calculate the total price")]
         public void WhenICalculateTheTotalPrice()
         {
-            var products = ScenarioContext.Current["Cart"] as List<CartItem>;
-            var discountCode = ScenarioContext.Current["Code"] as string;
+            var products = _scenarioContext["Cart"] as List<CartItem>;
+            var discountCode = _scenarioContext["Code"] as string;
 
             var calculator = new CartPriceCalculator();
 
             var price = calculator.ComputePrice(products, discountCode);
 
-            ScenarioContext.Current["Price"] = price;
+            _scenarioContext["Price"] = price;
 
         }
 
         [Then(@"the product price should be (.*)")]
         public void ThenTheProductPriceShouldBe(decimal productsPrice)
         {
-            var price = ScenarioContext.Current["Price"] as CartPrice;
+            var price = _scenarioContext["Price"] as CartPrice;
 
             Check.That(price.ProductCost).IsEqualTo(productsPrice);
         }
@@ -56,7 +63,7 @@ namespace TalentAgileShop.Cart.Tests.Steps
         [Then(@"the delivery price should be (.*)")]
         public void ThenTheDeliveryPriceShouldBe(decimal deliveryPrice)
         {
-            var price = ScenarioContext.Current["Price"] as CartPrice;
+            var price = _scenarioContext["Price"] as CartPrice;
 
             Check.That(price.DeliveryCost).IsEqualTo(deliveryPrice);
         }


### PR DESCRIPTION
Using the static ScenarioContext.Current could cause some errors when using NCrunch for live unit tests. Injecting the ScenarioContext instance through the constructor should fix the issue.